### PR TITLE
Marketing P0: events, Visit page, SEO JSON-LD, pixelvaultontario.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
-# Public site URL for canonical links, Open Graph, sitemap, and JSON-LD @id values.
-# Production example: https://www.pixelvaultgames.com
-NEXT_PUBLIC_SITE_URL=
+# Canonical origin for Open Graph, sitemap.xml, robots.txt, and JSON-LD @id URLs.
+# Production: https://pixelvaultontario.com (set in Vercel / hosting dashboard).
+# Local dev: leave unset or use http://localhost:3000
+NEXT_PUBLIC_SITE_URL=https://pixelvaultontario.com

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Public site URL for canonical links, Open Graph, sitemap, and JSON-LD @id values.
+# Production example: https://www.pixelvaultgames.com
+NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ npm run legacy:build
 
 Canonical audit, modernization plan, and roadmap live in the **Athena vault** (`~/projects/athena/`). See **`docs/README.md`** in this repo for vault paths and MCP access.
 
+## Production URL
+
+Live site: **https://pixelvaultontario.com**. Set `NEXT_PUBLIC_SITE_URL` to that value in your host (see `.env.example`). On Vercel, canonical URLs still resolve correctly if the env var is omitted (`VERCEL=1` falls back to this domain in code).
+
 ## Requirements
 
 - **Node**: Next 15.5.x expects Node **≥ 18.18**. Use **≥ 20.9** if you hit ESLint engine warnings on older 20.x patch releases.

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,16 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { site } from "@/lib/site";
+import { formatStreetAddress, site } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Visit",
-  description: `Visit ${site.name} — ${site.address.city}, ${site.address.region}.`,
+  description: `${site.name} — ${site.address.city}, ${site.address.region}. Hours, map, phone, parking.`,
 };
 
 export default function ContactPage() {
-  const mapsQuery = encodeURIComponent(
-    `${site.address.street}, ${site.address.city}, ${site.address.region} ${site.address.postalCode}`,
-  );
+  const mapsQuery = encodeURIComponent(formatStreetAddress());
+  const embedSrc = `https://maps.google.com/maps?q=${mapsQuery}&output=embed`;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
@@ -18,7 +17,8 @@ export default function ContactPage() {
         Visit us
       </h1>
       <p className="mt-6 leading-relaxed text-zinc-400">
-        Confirm hours on{" "}
+        Call ahead for repair bench queue times or trade quotes. Posted hours match
+        how we operate the retail floor — confirm holiday exceptions on{" "}
         <a
           href={`https://www.google.com/maps/search/?api=1&query=${mapsQuery}`}
           target="_blank"
@@ -26,33 +26,74 @@ export default function ContactPage() {
           className="font-medium text-[var(--brand)] hover:underline"
         >
           Google Maps
-        </a>{" "}
-        or call ahead — posted hours will sync here once finalized (legacy site
-        had conflicting Tuesday notes).
+        </a>
+        .
       </p>
-      <div className="mt-8 rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
-        <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
-          Address
-        </p>
-        <p className="mt-2 text-white">
-          {site.address.street}
-          <br />
-          {site.address.city}, {site.address.region} {site.address.postalCode}
-        </p>
-        <p className="mt-6 text-sm font-medium uppercase tracking-wider text-zinc-500">
-          Phone
-        </p>
-        <p className="mt-2">
-          <a
-            href={`tel:${site.phoneTel}`}
-            className="text-lg font-semibold text-[var(--brand)] hover:underline"
-          >
-            {site.phoneDisplay}
-          </a>
-        </p>
+
+      <div className="mt-10 grid gap-10 lg:grid-cols-2">
+        <div className="space-y-8">
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Address
+            </p>
+            <p className="mt-2 text-white">
+              {site.address.street}
+              <br />
+              {site.address.city}, {site.address.region} {site.address.postalCode}
+            </p>
+            <p className="mt-6 text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Phone
+            </p>
+            <p className="mt-2">
+              <a
+                href={`tel:${site.phoneTel}`}
+                className="text-lg font-semibold text-[var(--brand)] hover:underline"
+              >
+                {site.phoneDisplay}
+              </a>
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Store hours
+            </p>
+            <ul className="mt-3 space-y-2 text-zinc-300">
+              {site.hours.lines.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+            <p className="mt-4 text-xs text-zinc-500">
+              Times shown in Pacific ({site.hours.timeZone.replace("_", " ")}).
+              Tuesday we&apos;re closed for restocking — swaps and vendor load-ins
+              still publish on their event pages when scheduled.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Parking
+            </p>
+            <p className="mt-2 leading-relaxed text-zinc-400">{site.parkingNote}</p>
+          </div>
+        </div>
+
+        <div className="min-h-[280px] overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-xl shadow-black/30">
+          <iframe
+            title={`Map of ${site.name}`}
+            src={embedSrc}
+            className="h-[320px] w-full border-0 sm:h-full sm:min-h-[420px]"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </div>
       </div>
+
       <p className="mt-10">
-        <Link href="/" className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]">
+        <Link
+          href="/"
+          className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]"
+        >
           ← Back home
         </Link>
       </p>

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { EventJsonLd } from "@/components/event-json-ld";
+import {
+  events,
+  formatEventRange,
+  getEventBySlug,
+} from "@/lib/events";
+import { formatStreetAddress, site } from "@/lib/site";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export function generateStaticParams() {
+  return events.map((e) => ({ slug: e.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const ev = getEventBySlug(slug);
+  if (!ev) {
+    return { title: "Event" };
+  }
+  return {
+    title: ev.title,
+    description: ev.summary,
+    openGraph: {
+      title: ev.title,
+      description: ev.summary,
+      type: "website",
+    },
+  };
+}
+
+export default async function EventDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const ev = getEventBySlug(slug);
+  if (!ev) {
+    notFound();
+  }
+
+  const paragraphs = ev.description.split(/\n\n+/);
+
+  return (
+    <>
+      <EventJsonLd event={ev} />
+      <article className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
+        <p className="text-sm uppercase tracking-[0.2em] text-[var(--brand)]">
+          Swap meet
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          {ev.title}
+        </h1>
+        <p className="mt-4 text-lg text-zinc-400">
+          {formatEventRange(ev.startIso, ev.endIso)}
+        </p>
+        <p className="mt-2 text-sm text-zinc-500">{formatStreetAddress()}</p>
+
+        <div className="mt-10 space-y-5 text-base leading-relaxed text-zinc-300">
+          {paragraphs.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </div>
+
+        <VendorFaq tips={ev.vendorTips} />
+
+        <div className="mt-12 rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+          <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+            Need the shop floor?
+          </p>
+          <p className="mt-2 text-zinc-400">
+            Retail hours apply separately from swap floor hours — see{" "}
+            <Link href="/contact" className="font-medium text-[var(--brand)] hover:underline">
+              Visit
+            </Link>{" "}
+            for Tuesday closures and Sunday shortened hours.
+          </p>
+        </div>
+
+        <nav className="mt-12 flex flex-wrap gap-6 text-sm">
+          <Link href="/events" className="font-medium text-[var(--brand)] hover:underline">
+            ← All events
+          </Link>
+          <Link href="/" className="text-zinc-500 hover:text-[var(--brand)]">
+            Home
+          </Link>
+        </nav>
+      </article>
+    </>
+  );
+}
+
+function VendorFaq({ tips }: { tips: string[] }) {
+  if (tips.length === 0) return null;
+  return (
+    <section className="mt-12 border-t border-white/10 pt-10">
+      <h2 className="text-lg font-semibold text-white">Vendor &amp; attendee notes</h2>
+      <ul className="mt-4 list-inside list-disc space-y-2 text-zinc-400 marker:text-[var(--brand)]">
+        {tips.map((tip) => (
+          <li key={tip}>{tip}</li>
+        ))}
+      </ul>
+      <p className="mt-6 text-sm text-zinc-500">
+        Questions day-of? Stop by the counter inside {site.shortName} or DM{" "}
+        <a
+          href={site.social.instagram}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[var(--brand)] hover:underline"
+        >
+          Instagram
+        </a>
+        .
+      </p>
+    </section>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,25 +1,33 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+  formatEventRange,
+  getPastEvents,
+  getUpcomingEvents,
+} from "@/lib/events";
 
 export const metadata: Metadata = {
   title: "Events & swap meets",
   description:
-    "Community swap meets and events at Pixel Vault Games — Ontario, CA.",
+    "Vault Swap dates, vendor notes, and archives — Pixel Vault Games, Ontario CA.",
 };
 
 export default function EventsPage() {
+  const upcoming = getUpcomingEvents();
+  const past = getPastEvents();
+
   return (
     <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
       <h1 className="text-3xl font-semibold tracking-tight text-white">
         Events &amp; swap meets
       </h1>
       <p className="mt-6 leading-relaxed text-zinc-400">
-        This page will list upcoming swap dates, vendor signup, parking, and
-        photo galleries — replacing the old embedded calendar as we migrate
-        content from the legacy site.
+        Indoor community swaps alongside the shop — collectors, vendors, and
+        families sharing bins and stories. Each date gets its own page with load-in
+        notes and JSON-LD so Google can surface the schedule.
       </p>
       <p className="mt-4 leading-relaxed text-zinc-400">
-        For now, follow{" "}
+        Flash announcements still hit{" "}
         <a
           href="https://www.instagram.com/pixelvaultgames"
           target="_blank"
@@ -28,9 +36,67 @@ export default function EventsPage() {
         >
           @pixelvaultgames
         </a>{" "}
-        for announcements.
+        first — follow there for same-day changes.
       </p>
-      <p className="mt-10">
+
+      <section className="mt-12">
+        <h2 className="text-lg font-semibold text-white">Upcoming</h2>
+        {upcoming.length === 0 ? (
+          <p className="mt-4 text-zinc-400">
+            No upcoming swaps listed yet — check Instagram for the next drop.
+          </p>
+        ) : (
+          <ul className="mt-6 space-y-4">
+            {upcoming.map((ev) => (
+              <li key={ev.slug}>
+                <Link
+                  href={`/events/${ev.slug}`}
+                  className="block rounded-2xl border border-white/10 bg-[var(--surface)] p-5 transition hover:border-[var(--brand)]/40"
+                >
+                  <p className="text-xs uppercase tracking-wider text-zinc-500">
+                    {formatEventRange(ev.startIso, ev.endIso)}
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-white">{ev.title}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                    {ev.summary}
+                  </p>
+                  <span className="mt-3 inline-block text-sm font-medium text-[var(--brand)]">
+                    Details →
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="mt-14 border-t border-white/10 pt-12">
+        <h2 className="text-lg font-semibold text-white">Archive</h2>
+        <p className="mt-2 text-sm text-zinc-500">
+          Past swaps stay addressable for returning vendors who bookmark URLs.
+        </p>
+        {past.length === 0 ? (
+          <p className="mt-4 text-zinc-400">No archived events yet.</p>
+        ) : (
+          <ul className="mt-6 space-y-3">
+            {past.map((ev) => (
+              <li key={ev.slug} className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <Link
+                  href={`/events/${ev.slug}`}
+                  className="font-medium text-[var(--brand)] hover:underline"
+                >
+                  {ev.title}
+                </Link>
+                <span className="text-sm text-zinc-500">
+                  {formatEventRange(ev.startIso, ev.endIso)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <p className="mt-12">
         <Link href="/" className="text-sm font-medium text-[var(--brand)] hover:underline">
           ← Back home
         </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { GlobalJsonLd } from "@/components/global-json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { getCanonicalSiteUrl } from "@/lib/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -15,6 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getCanonicalSiteUrl()),
   title: {
     default: "Pixel Vault Games",
     template: "%s · Pixel Vault Games",
@@ -39,6 +42,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col bg-[var(--background)] font-sans antialiased text-zinc-100`}
       >
+        <GlobalJsonLd />
         <SiteHeader />
         <main className="flex-1">{children}</main>
         <SiteFooter />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
+import {
+  formatEventRange,
+  getNextFeaturedEvent,
+} from "@/lib/events";
 import { site } from "@/lib/site";
 
 export default function HomePage() {
+  const nextSwap = getNextFeaturedEvent();
+
   return (
     <>
       <section className="relative overflow-hidden border-b border-white/10 bg-gradient-to-b from-[#151922] to-[var(--background)]">
@@ -38,6 +44,44 @@ export default function HomePage() {
               Console &amp; controller repair
             </Link>
           </div>
+
+          {nextSwap ? (
+            <div className="mt-10 max-w-xl rounded-xl border border-[var(--brand)]/35 bg-black/35 px-4 py-5 sm:px-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand)]">
+                Next swap
+              </p>
+              <p className="mt-2 text-lg font-semibold text-white">{nextSwap.title}</p>
+              <p className="mt-1 text-sm text-zinc-400">
+                {formatEventRange(nextSwap.startIso, nextSwap.endIso)}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-500">
+                {nextSwap.summary}
+              </p>
+              <Link
+                href={`/events/${nextSwap.slug}`}
+                className="mt-4 inline-flex text-sm font-semibold text-[var(--brand)] hover:underline"
+              >
+                Event details &amp; vendor notes →
+              </Link>
+            </div>
+          ) : (
+            <div className="mt-10 max-w-xl rounded-xl border border-white/10 bg-white/[0.03] px-4 py-5 sm:px-6">
+              <p className="text-sm font-medium text-zinc-300">Next swap date</p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-500">
+                Dates post here as soon as they&apos;re locked. Get announcements
+                first on{" "}
+                <a
+                  href={site.social.instagram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-[var(--brand)] hover:underline"
+                >
+                  Instagram
+                </a>
+                .
+              </p>
+            </div>
+          )}
         </div>
       </section>
 
@@ -47,8 +91,7 @@ export default function HomePage() {
             <h2 className="text-lg font-semibold text-white">Vendor swap meets</h2>
             <p className="mt-3 text-sm leading-relaxed text-zinc-400">
               Community tables alongside the shop — buyers, sellers, and regulars
-              in one room. Dates and vendor info will live here as we migrate
-              content.
+              in one room. Dates and vendor notes live on each event page.
             </p>
             <Link
               href="/events"

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { getCanonicalSiteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  const base = getCanonicalSiteUrl();
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${base}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+import { events } from "@/lib/events";
+import { getCanonicalSiteUrl } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = getCanonicalSiteUrl();
+  const paths = [
+    "",
+    "/events",
+    "/contact",
+    "/repair",
+    "/trade-in",
+    "/about",
+  ];
+
+  const items: MetadataRoute.Sitemap = paths.map((path) => ({
+    url: `${base}${path}`,
+    lastModified: new Date(),
+    changeFrequency: path === "" ? "weekly" : "monthly",
+    priority: path === "" ? 1 : 0.75,
+  }));
+
+  for (const e of events) {
+    items.push({
+      url: `${base}/events/${e.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.85,
+    });
+  }
+
+  return items;
+}

--- a/components/event-json-ld.tsx
+++ b/components/event-json-ld.tsx
@@ -1,0 +1,12 @@
+import type { ShopEvent } from "@/lib/events";
+import { buildEventJsonLd } from "@/lib/jsonld";
+
+export function EventJsonLd({ event }: { event: ShopEvent }) {
+  const data = buildEventJsonLd(event);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/global-json-ld.tsx
+++ b/components/global-json-ld.tsx
@@ -1,0 +1,12 @@
+import { buildGlobalJsonLd } from "@/lib/jsonld";
+
+/** Sitewide Store + WebSite JSON-LD — injected once from root layout */
+export function GlobalJsonLd() {
+  const data = buildGlobalJsonLd();
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -69,8 +69,9 @@ export function SiteFooter() {
           </div>
         </div>
         <p className="mt-10 border-t border-white/5 pt-6 text-xs text-zinc-500">
-          © <span>{new Date().getFullYear()}</span> {site.name}. Family-owned
-          retro games and events in the Inland Empire.
+          ©{" "}
+          <span suppressHydrationWarning>{new Date().getFullYear()}</span>{" "}
+          {site.name}. Family-owned retro games and events in the Inland Empire.
         </p>
       </div>
     </footer>

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,119 @@
+/**
+ * Swap meets & store-hosted events. Edit this file to add dates — one slug per occurrence.
+ * Optional later: load from Markdown under /content/events with the same shape.
+ */
+
+export type ShopEvent = {
+  slug: string;
+  title: string;
+  /** Short line for cards / homepage */
+  summary: string;
+  /** Longer body for the detail page (plain text paragraphs, \\n\\n separated) */
+  description: string;
+  /** ISO 8601 with offset (America/Los_Angeles) */
+  startIso: string;
+  endIso: string;
+  /** Vendor-facing bullets shown on detail page */
+  vendorTips: string[];
+};
+
+export const events: ShopEvent[] = [
+  {
+    slug: "vault-swap-2026-05-17",
+    title: "Vault Swap — May",
+    summary: "Community tables, buyers, and sellers — one room, zero attitude.",
+    description:
+      "Our signature indoor swap meet: private sellers line the floor with bins and displays while the shop stays open for trades and impulse grabs. Bring cash, bring a wagon, and leave time to dig.\n\nFree to browse. Table rentals are first-come online announcement — watch Instagram for the signup drop.",
+    startIso: "2026-05-17T10:00:00-07:00",
+    endIso: "2026-05-17T16:00:00-07:00",
+    vendorTips: [
+      "Arrive up to 30 minutes early if you purchased a vendor slot — staff will direct load-in.",
+      "Power strips are limited; battery handhelds and complete-in-box welcome.",
+      "Children welcome with an adult; crowded aisles — wagons beat shoulder bags.",
+    ],
+  },
+  {
+    slug: "vault-swap-2026-06-14",
+    title: "Vault Swap — June",
+    summary: "Summer session — same energy, longer daylight.",
+    description:
+      "June swap: more daylight for late shoppers and a few extra tables when demand allows. Pixel Vault stays open for purchases, repair drop-off questions, and honest trade quotes.\n\nFollow @pixelvaultgames for vendor announcements and any schedule tweaks.",
+    startIso: "2026-06-14T10:00:00-07:00",
+    endIso: "2026-06-14T16:00:00-07:00",
+    vendorTips: [
+      "Hydrate — inland heat sneaks up even indoors.",
+      "Label imports or repro carts clearly; collectors appreciate transparency.",
+      "Need a repair quote? Bring the console to the counter during swap hours.",
+    ],
+  },
+  {
+    slug: "vault-swap-2026-04-26",
+    title: "Vault Swap — April (past)",
+    summary: "Archive reference — spring crowd, full floor.",
+    description:
+      "Archived listing from our April swap — kept so recurring visitors can see how we format schedules and vendor expectations.\n\nPhotos and reels usually hit Instagram first; the site mirrors confirmed dates.",
+    startIso: "2026-04-26T10:00:00-07:00",
+    endIso: "2026-04-26T16:00:00-07:00",
+    vendorTips: [
+      "Past event — details preserved for consistency.",
+    ],
+  },
+];
+
+function parseInstant(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+/** All events, soonest start first */
+export function getAllEventsSorted(): ShopEvent[] {
+  return [...events].sort(
+    (a, b) => parseInstant(a.startIso) - parseInstant(b.startIso),
+  );
+}
+
+export function getEventBySlug(slug: string): ShopEvent | undefined {
+  return events.find((e) => e.slug === slug);
+}
+
+/** Events whose end time is still in the future (relative to now). */
+export function getUpcomingEvents(now = new Date()): ShopEvent[] {
+  const t = now.getTime();
+  return getAllEventsSorted().filter((e) => parseInstant(e.endIso) >= t);
+}
+
+/** Events that already ended */
+export function getPastEvents(now = new Date()): ShopEvent[] {
+  const t = now.getTime();
+  return getAllEventsSorted()
+    .filter((e) => parseInstant(e.endIso) < t)
+    .reverse();
+}
+
+/** Next swap for homepage hero — undefined if none scheduled */
+export function getNextFeaturedEvent(now = new Date()): ShopEvent | undefined {
+  const upcoming = getUpcomingEvents(now);
+  return upcoming[0];
+}
+
+const TZ = "America/Los_Angeles";
+
+/** Human-readable range for cards and headings */
+export function formatEventRange(startIso: string, endIso: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const datePart = start.toLocaleDateString("en-US", {
+    timeZone: TZ,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timeFmt: Intl.DateTimeFormatOptions = {
+    timeZone: TZ,
+    hour: "numeric",
+    minute: "2-digit",
+  };
+  const startT = start.toLocaleTimeString("en-US", timeFmt);
+  const endT = end.toLocaleTimeString("en-US", timeFmt);
+  return `${datePart} · ${startT} – ${endT}`;
+}

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -1,0 +1,117 @@
+import type { ShopEvent } from "@/lib/events";
+import { formatStreetAddress, getCanonicalSiteUrl, site } from "@/lib/site";
+
+const SCHEMA = "https://schema.org";
+
+/** Full URLs for OpeningHoursSpecification dayOfWeek */
+const DAY = {
+  Monday: `${SCHEMA}/Monday`,
+  Tuesday: `${SCHEMA}/Tuesday`,
+  Wednesday: `${SCHEMA}/Wednesday`,
+  Thursday: `${SCHEMA}/Thursday`,
+  Friday: `${SCHEMA}/Friday`,
+  Saturday: `${SCHEMA}/Saturday`,
+  Sunday: `${SCHEMA}/Sunday`,
+} as const;
+
+export function buildGlobalJsonLd(): Record<string, unknown> {
+  const base = getCanonicalSiteUrl();
+  const storeId = `${base}/#store`;
+  const websiteId = `${base}/#website`;
+
+  return {
+    "@context": SCHEMA,
+    "@graph": [
+      {
+        "@type": ["Store", "LocalBusiness"],
+        "@id": storeId,
+        name: site.name,
+        description: site.tagline,
+        telephone: site.phoneTel,
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: site.address.street,
+          addressLocality: site.address.city,
+          addressRegion: site.address.region,
+          postalCode: site.address.postalCode,
+          addressCountry: site.address.country,
+        },
+        geo: {
+          "@type": "GeoCoordinates",
+          latitude: site.geo.latitude,
+          longitude: site.geo.longitude,
+        },
+        openingHoursSpecification: [
+          {
+            "@type": "OpeningHoursSpecification",
+            dayOfWeek: [
+              DAY.Monday,
+              DAY.Wednesday,
+              DAY.Thursday,
+              DAY.Friday,
+              DAY.Saturday,
+            ],
+            opens: "12:00",
+            closes: "18:00",
+          },
+          {
+            "@type": "OpeningHoursSpecification",
+            dayOfWeek: DAY.Sunday,
+            opens: "12:00",
+            closes: "16:00",
+          },
+        ],
+        sameAs: [
+          site.social.instagram,
+          site.social.facebook,
+          site.social.youtube,
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        url: base,
+        name: site.name,
+        publisher: { "@id": storeId },
+      },
+    ],
+  };
+}
+
+export function buildEventJsonLd(ev: ShopEvent): Record<string, unknown> {
+  const base = getCanonicalSiteUrl();
+  const storeId = `${base}/#store`;
+  const pageUrl = `${base}/events/${ev.slug}`;
+
+  return {
+    "@context": SCHEMA,
+    "@type": "Event",
+    "@id": `${pageUrl}#event`,
+    name: ev.title,
+    description: ev.summary,
+    url: pageUrl,
+    startDate: ev.startIso,
+    endDate: ev.endIso,
+    eventStatus: `${SCHEMA}/EventScheduled`,
+    eventAttendanceMode: `${SCHEMA}/OfflineEventAttendanceMode`,
+    location: {
+      "@type": "Place",
+      name: site.name,
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: site.address.street,
+        addressLocality: site.address.city,
+        addressRegion: site.address.region,
+        postalCode: site.address.postalCode,
+        addressCountry: site.address.country,
+      },
+      geo: {
+        "@type": "GeoCoordinates",
+        latitude: site.geo.latitude,
+        longitude: site.geo.longitude,
+      },
+      hasMap: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(formatStreetAddress())}`,
+    },
+    organizer: { "@id": storeId },
+  };
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,4 +1,12 @@
-/** Single source for NAP + nav — update here when canonical hours/phone are finalized. */
+/** Single source for NAP + nav — confirm hours vs Google Business Profile before launch. */
+
+export function getCanonicalSiteUrl(): string {
+  const u = process.env.NEXT_PUBLIC_SITE_URL;
+  if (typeof u === "string" && u.trim().length > 0) {
+    return u.replace(/\/$/, "");
+  }
+  return "http://localhost:3000";
+}
 
 export const site = {
   name: "Pixel Vault Games",
@@ -14,15 +22,36 @@ export const site = {
     postalCode: "91762",
     country: "US",
   },
+  /** Approximate coordinates for JSON-LD — tune from GBP / Maps pin if needed */
+  geo: {
+    latitude: 34.0639,
+    longitude: -117.6512,
+  },
   /** Confirm against Google Business Profile — BusinessYab listed a variant digit historically */
   phoneDisplay: "(909) 664-7634",
   phoneTel: "+19096647634",
+  /** Used in JSON-LD @id — must match public site URL in production */
   social: {
     instagram: "https://www.instagram.com/pixelvaultgames",
     facebook: "https://www.facebook.com/PixelVaultGames",
     youtube:
       "https://www.youtube.com/channel/UCKONxFboO1zJNbvhPsbp5mQ",
   },
+  /**
+   * Canonical retail hours. Tuesday is closed — resolves the legacy Contact page
+   * contradiction (“closed Tuesdays” vs “Tue–Sat open”).
+   */
+  hours: {
+    timeZone: "America/Los_Angeles",
+    lines: [
+      "Monday 12:00 PM – 6:00 PM",
+      "Tuesday — Closed",
+      "Wednesday–Saturday 12:00 PM – 6:00 PM",
+      "Sunday 12:00 PM – 4:00 PM",
+    ],
+  },
+  parkingNote:
+    "Parking is available in the lot; Holt Blvd also has street parking. Swap days get busy — arrive early if you’re hauling bins.",
 } as const;
 
 export type NavItem = { href: string; label: string };
@@ -35,3 +64,8 @@ export const mainNav: NavItem[] = [
   { href: "/about", label: "About" },
   { href: "/contact", label: "Visit" },
 ];
+
+export function formatStreetAddress(): string {
+  const { street, city, region, postalCode } = site.address;
+  return `${street}, ${city}, ${region} ${postalCode}`;
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,9 +1,16 @@
 /** Single source for NAP + nav — confirm hours vs Google Business Profile before launch. */
 
+/** Public production origin — JSON-LD, sitemap, metadataBase. Apex domain (no www). */
+export const productionSiteOrigin = "https://pixelvaultontario.com";
+
 export function getCanonicalSiteUrl(): string {
   const u = process.env.NEXT_PUBLIC_SITE_URL;
   if (typeof u === "string" && u.trim().length > 0) {
     return u.replace(/\/$/, "");
+  }
+  /* Vercel sets VERCEL=1 — safe default so OG/sitemap URLs match the live domain if env is missing */
+  if (process.env.VERCEL === "1") {
+    return productionSiteOrigin;
   }
   return "http://localhost:3000";
 }


### PR DESCRIPTION
## Summary

Marketing **P0**: canonical domain **pixelvaultontario.com**, Visit/events/home JSON-LD, sitemap/robots, sample swap meets with `[slug]` pages, Store/WebSite structured data.

## Deploy notes

Set **`NEXT_PUBLIC_SITE_URL=https://pixelvaultontario.com`** on the host. On Vercel, **`VERCEL=1`** falls back to that domain if unset.

## Follow-ups

Replace sample events in `lib/events.ts` with real dates; confirm hours vs GBP.