### PR TITLE
P1: Repair, trade-in, about — marketing layout + legacy photo map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
-# Public site URL for canonical links, Open Graph, sitemap, and JSON-LD @id values.
-# Production example: https://www.pixelvaultgames.com
-NEXT_PUBLIC_SITE_URL=
+# Canonical origin for Open Graph, sitemap.xml, robots.txt, and JSON-LD @id URLs.
+# Production: https://pixelvaultontario.com (set in Vercel / hosting dashboard).
+# Local dev: leave unset or use http://localhost:3000
+NEXT_PUBLIC_SITE_URL=https://pixelvaultontario.com

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Public site URL for canonical links, Open Graph, sitemap, and JSON-LD @id values.
+# Production example: https://www.pixelvaultgames.com
+NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ npm run legacy:build
 
 Canonical audit, modernization plan, and roadmap live in the **Athena vault** (`~/projects/athena/`). See **`docs/README.md`** in this repo for vault paths and MCP access.
 
+## Production URL
+
+Live site: **https://pixelvaultontario.com**. Set `NEXT_PUBLIC_SITE_URL` to that value in your host (see `.env.example`). On Vercel, canonical URLs still resolve correctly if the env var is omitted (`VERCEL=1` falls back to this domain in code).
+
 ## Requirements
 
 - **Node**: Next 15.5.x expects Node **≥ 18.18**. Use **≥ 20.9** if you hit ESLint engine warnings on older 20.x patch releases.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { DropCta } from "@/components/marketing/drop-cta";
+import { IllustrationCommunity } from "@/components/marketing/illustrations";
+import { PageHero } from "@/components/marketing/page-hero";
+import { PillRow } from "@/components/marketing/pill-row";
 import { site } from "@/lib/site";
 
 export const metadata: Metadata = {
@@ -7,32 +11,109 @@ export const metadata: Metadata = {
   description: `${site.name} — family-owned retro games in Ontario, CA since ${site.foundedYear}.`,
 };
 
+const pills = ["Family-owned", "Swap hosts", "Collectors welcome", "Kids & carts"];
+
 export default function AboutPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
-      <h1 className="text-3xl font-semibold tracking-tight text-white">
-        About {site.shortName}
-      </h1>
-      <p className="mt-6 leading-relaxed text-zinc-400">
-        We&apos;re a family-owned shop in Ontario. {site.tagline} Since{" "}
-        {site.foundedYear}, we&apos;ve aimed to be the Inland Empire&apos;s welcoming spot
-        for collectors, parents introducing kids to classics, and anyone who
-        misses the good old days.
-      </p>
-      <p className="mt-4 leading-relaxed text-zinc-400">
-        Staff bios, photos, and &quot;what we&apos;re playing&quot; will land here in a
-        future pass — owner-led voice matters for this site.
-      </p>
-      <p className="mt-10">
-        <Link href="/contact" className="font-medium text-[var(--brand)] hover:underline">
-          Visit us →
-        </Link>
-      </p>
-      <p className="mt-6">
-        <Link href="/" className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]">
-          ← Back home
-        </Link>
-      </p>
-    </div>
+    <>
+      <PageHero
+        eyebrow={`Since ${site.foundedYear}`}
+        title={
+          <>
+            Anti-corporate vibes,{" "}
+            <span className="text-[var(--brand)]">pro-community energy</span>
+          </>
+        }
+        subtitle={`${site.name} is a family-run shop on Holt — not a venture-backed flip house. We bias toward collector literacy: label your repro carts, celebrate weird imports, and keep trades respectful.`}
+        illustration={
+          <div className="w-full max-w-[min(100%,320px)] drop-shadow-2xl drop-shadow-black/50">
+            <IllustrationCommunity className="h-auto w-full" />
+          </div>
+        }
+      >
+        <PillRow items={pills} />
+      </PageHero>
+
+      <section className="border-t border-white/10 bg-black/25 py-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="grid gap-12 lg:grid-cols-[1fr_320px] lg:items-start">
+            <div className="space-y-8">
+              <div>
+                <h2 className="text-2xl font-semibold text-white">Why we lead with swap meets</h2>
+                <p className="mt-4 leading-relaxed text-zinc-400">
+                  Anyone can list inventory — fewer shops host recurring rooms where locals rent tables
+                  next to the aisles. That signal matters to collectors driving from Riverside,
+                  Rancho, or Claremont: proof that the hobby still gathers IRL.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+                <h3 className="text-lg font-semibold text-white">Voice &amp; tone</h3>
+                <p className="mt-3 text-sm leading-relaxed text-zinc-400">
+                  Owner-led shops score trust when they sound human — not brochure-clean. We&apos;ll
+                  keep bios candid once photos land; until then, swing through in person and judge
+                  for yourself.
+                </p>
+              </div>
+            </div>
+            <aside className="space-y-6">
+              <div className="rounded-2xl border border-[var(--brand)]/20 bg-gradient-to-b from-[var(--surface)] to-zinc-950 p-6">
+                <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                  Milestones
+                </p>
+                <ul className="mt-4 space-y-4 border-l border-[var(--brand)]/40 pl-5">
+                  <li>
+                    <p className="text-sm font-semibold text-[var(--brand)]">{site.foundedYear}</p>
+                    <p className="text-sm text-zinc-400">Opened on Holt — cartridges before algorithms.</p>
+                  </li>
+                  <li>
+                    <p className="text-sm font-semibold text-white">Today</p>
+                    <p className="text-sm text-zinc-400">
+                      Repair bench + buy/sell/trade + hosted swaps — destination, not catalog.
+                    </p>
+                  </li>
+                </ul>
+              </div>
+              <DropCta
+                title="Come meet the room"
+                description="Swap weekends feel different than weekday aisles — check the next date."
+                href="/events"
+                label="Events calendar"
+              />
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-14">
+        <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
+          <p className="text-sm uppercase tracking-[0.2em] text-zinc-500">Photos soon</p>
+          <p className="mt-4 text-lg leading-relaxed text-zinc-400">
+            Drop team shots + floor photography into{" "}
+            <code className="rounded bg-white/5 px-2 py-0.5 text-sm text-[var(--brand)]">
+              public/images/store/
+            </code>{" "}
+            — we&apos;ll wire a gallery once assets arrive (legacy Home shots: games-in-case,
+            consoles &amp; controllers, character display).
+          </p>
+          <Link
+            href="/contact"
+            className="mt-8 inline-block text-sm font-semibold text-[var(--brand)] hover:underline"
+          >
+            Visit us →
+          </Link>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 py-10">
+        <div className="mx-auto flex max-w-3xl flex-wrap justify-between gap-4 px-4 sm:px-6">
+          <Link href="/" className="text-sm text-zinc-500 hover:text-[var(--brand)]">
+            ← Home
+          </Link>
+          <Link href="/trade-in" className="text-sm font-medium text-[var(--brand)] hover:underline">
+            Trade-in policy →
+          </Link>
+        </div>
+      </section>
+    </>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,16 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { site } from "@/lib/site";
+import { formatStreetAddress, site } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Visit",
-  description: `Visit ${site.name} — ${site.address.city}, ${site.address.region}.`,
+  description: `${site.name} — ${site.address.city}, ${site.address.region}. Hours, map, phone, parking.`,
 };
 
 export default function ContactPage() {
-  const mapsQuery = encodeURIComponent(
-    `${site.address.street}, ${site.address.city}, ${site.address.region} ${site.address.postalCode}`,
-  );
+  const mapsQuery = encodeURIComponent(formatStreetAddress());
+  const embedSrc = `https://maps.google.com/maps?q=${mapsQuery}&output=embed`;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
@@ -18,7 +17,8 @@ export default function ContactPage() {
         Visit us
       </h1>
       <p className="mt-6 leading-relaxed text-zinc-400">
-        Confirm hours on{" "}
+        Call ahead for repair bench queue times or trade quotes. Posted hours match
+        how we operate the retail floor — confirm holiday exceptions on{" "}
         <a
           href={`https://www.google.com/maps/search/?api=1&query=${mapsQuery}`}
           target="_blank"
@@ -26,33 +26,74 @@ export default function ContactPage() {
           className="font-medium text-[var(--brand)] hover:underline"
         >
           Google Maps
-        </a>{" "}
-        or call ahead — posted hours will sync here once finalized (legacy site
-        had conflicting Tuesday notes).
+        </a>
+        .
       </p>
-      <div className="mt-8 rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
-        <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
-          Address
-        </p>
-        <p className="mt-2 text-white">
-          {site.address.street}
-          <br />
-          {site.address.city}, {site.address.region} {site.address.postalCode}
-        </p>
-        <p className="mt-6 text-sm font-medium uppercase tracking-wider text-zinc-500">
-          Phone
-        </p>
-        <p className="mt-2">
-          <a
-            href={`tel:${site.phoneTel}`}
-            className="text-lg font-semibold text-[var(--brand)] hover:underline"
-          >
-            {site.phoneDisplay}
-          </a>
-        </p>
+
+      <div className="mt-10 grid gap-10 lg:grid-cols-2">
+        <div className="space-y-8">
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Address
+            </p>
+            <p className="mt-2 text-white">
+              {site.address.street}
+              <br />
+              {site.address.city}, {site.address.region} {site.address.postalCode}
+            </p>
+            <p className="mt-6 text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Phone
+            </p>
+            <p className="mt-2">
+              <a
+                href={`tel:${site.phoneTel}`}
+                className="text-lg font-semibold text-[var(--brand)] hover:underline"
+              >
+                {site.phoneDisplay}
+              </a>
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Store hours
+            </p>
+            <ul className="mt-3 space-y-2 text-zinc-300">
+              {site.hours.lines.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+            <p className="mt-4 text-xs text-zinc-500">
+              Times shown in Pacific ({site.hours.timeZone.replace("_", " ")}).
+              Tuesday we&apos;re closed for restocking — swaps and vendor load-ins
+              still publish on their event pages when scheduled.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+            <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+              Parking
+            </p>
+            <p className="mt-2 leading-relaxed text-zinc-400">{site.parkingNote}</p>
+          </div>
+        </div>
+
+        <div className="min-h-[280px] overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-xl shadow-black/30">
+          <iframe
+            title={`Map of ${site.name}`}
+            src={embedSrc}
+            className="h-[320px] w-full border-0 sm:h-full sm:min-h-[420px]"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </div>
       </div>
+
       <p className="mt-10">
-        <Link href="/" className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]">
+        <Link
+          href="/"
+          className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]"
+        >
           ← Back home
         </Link>
       </p>

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { EventJsonLd } from "@/components/event-json-ld";
+import {
+  events,
+  formatEventRange,
+  getEventBySlug,
+} from "@/lib/events";
+import { formatStreetAddress, site } from "@/lib/site";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export function generateStaticParams() {
+  return events.map((e) => ({ slug: e.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const ev = getEventBySlug(slug);
+  if (!ev) {
+    return { title: "Event" };
+  }
+  return {
+    title: ev.title,
+    description: ev.summary,
+    openGraph: {
+      title: ev.title,
+      description: ev.summary,
+      type: "website",
+    },
+  };
+}
+
+export default async function EventDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const ev = getEventBySlug(slug);
+  if (!ev) {
+    notFound();
+  }
+
+  const paragraphs = ev.description.split(/\n\n+/);
+
+  return (
+    <>
+      <EventJsonLd event={ev} />
+      <article className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
+        <p className="text-sm uppercase tracking-[0.2em] text-[var(--brand)]">
+          Swap meet
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          {ev.title}
+        </h1>
+        <p className="mt-4 text-lg text-zinc-400">
+          {formatEventRange(ev.startIso, ev.endIso)}
+        </p>
+        <p className="mt-2 text-sm text-zinc-500">{formatStreetAddress()}</p>
+
+        <div className="mt-10 space-y-5 text-base leading-relaxed text-zinc-300">
+          {paragraphs.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </div>
+
+        <VendorFaq tips={ev.vendorTips} />
+
+        <div className="mt-12 rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+          <p className="text-sm font-medium uppercase tracking-wider text-zinc-500">
+            Need the shop floor?
+          </p>
+          <p className="mt-2 text-zinc-400">
+            Retail hours apply separately from swap floor hours — see{" "}
+            <Link href="/contact" className="font-medium text-[var(--brand)] hover:underline">
+              Visit
+            </Link>{" "}
+            for Tuesday closures and Sunday shortened hours.
+          </p>
+        </div>
+
+        <nav className="mt-12 flex flex-wrap gap-6 text-sm">
+          <Link href="/events" className="font-medium text-[var(--brand)] hover:underline">
+            ← All events
+          </Link>
+          <Link href="/" className="text-zinc-500 hover:text-[var(--brand)]">
+            Home
+          </Link>
+        </nav>
+      </article>
+    </>
+  );
+}
+
+function VendorFaq({ tips }: { tips: string[] }) {
+  if (tips.length === 0) return null;
+  return (
+    <section className="mt-12 border-t border-white/10 pt-10">
+      <h2 className="text-lg font-semibold text-white">Vendor &amp; attendee notes</h2>
+      <ul className="mt-4 list-inside list-disc space-y-2 text-zinc-400 marker:text-[var(--brand)]">
+        {tips.map((tip) => (
+          <li key={tip}>{tip}</li>
+        ))}
+      </ul>
+      <p className="mt-6 text-sm text-zinc-500">
+        Questions day-of? Stop by the counter inside {site.shortName} or DM{" "}
+        <a
+          href={site.social.instagram}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[var(--brand)] hover:underline"
+        >
+          Instagram
+        </a>
+        .
+      </p>
+    </section>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,25 +1,33 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+  formatEventRange,
+  getPastEvents,
+  getUpcomingEvents,
+} from "@/lib/events";
 
 export const metadata: Metadata = {
   title: "Events & swap meets",
   description:
-    "Community swap meets and events at Pixel Vault Games — Ontario, CA.",
+    "Vault Swap dates, vendor notes, and archives — Pixel Vault Games, Ontario CA.",
 };
 
 export default function EventsPage() {
+  const upcoming = getUpcomingEvents();
+  const past = getPastEvents();
+
   return (
     <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
       <h1 className="text-3xl font-semibold tracking-tight text-white">
         Events &amp; swap meets
       </h1>
       <p className="mt-6 leading-relaxed text-zinc-400">
-        This page will list upcoming swap dates, vendor signup, parking, and
-        photo galleries — replacing the old embedded calendar as we migrate
-        content from the legacy site.
+        Indoor community swaps alongside the shop — collectors, vendors, and
+        families sharing bins and stories. Each date gets its own page with load-in
+        notes and JSON-LD so Google can surface the schedule.
       </p>
       <p className="mt-4 leading-relaxed text-zinc-400">
-        For now, follow{" "}
+        Flash announcements still hit{" "}
         <a
           href="https://www.instagram.com/pixelvaultgames"
           target="_blank"
@@ -28,9 +36,67 @@ export default function EventsPage() {
         >
           @pixelvaultgames
         </a>{" "}
-        for announcements.
+        first — follow there for same-day changes.
       </p>
-      <p className="mt-10">
+
+      <section className="mt-12">
+        <h2 className="text-lg font-semibold text-white">Upcoming</h2>
+        {upcoming.length === 0 ? (
+          <p className="mt-4 text-zinc-400">
+            No upcoming swaps listed yet — check Instagram for the next drop.
+          </p>
+        ) : (
+          <ul className="mt-6 space-y-4">
+            {upcoming.map((ev) => (
+              <li key={ev.slug}>
+                <Link
+                  href={`/events/${ev.slug}`}
+                  className="block rounded-2xl border border-white/10 bg-[var(--surface)] p-5 transition hover:border-[var(--brand)]/40"
+                >
+                  <p className="text-xs uppercase tracking-wider text-zinc-500">
+                    {formatEventRange(ev.startIso, ev.endIso)}
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-white">{ev.title}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                    {ev.summary}
+                  </p>
+                  <span className="mt-3 inline-block text-sm font-medium text-[var(--brand)]">
+                    Details →
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="mt-14 border-t border-white/10 pt-12">
+        <h2 className="text-lg font-semibold text-white">Archive</h2>
+        <p className="mt-2 text-sm text-zinc-500">
+          Past swaps stay addressable for returning vendors who bookmark URLs.
+        </p>
+        {past.length === 0 ? (
+          <p className="mt-4 text-zinc-400">No archived events yet.</p>
+        ) : (
+          <ul className="mt-6 space-y-3">
+            {past.map((ev) => (
+              <li key={ev.slug} className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <Link
+                  href={`/events/${ev.slug}`}
+                  className="font-medium text-[var(--brand)] hover:underline"
+                >
+                  {ev.title}
+                </Link>
+                <span className="text-sm text-zinc-500">
+                  {formatEventRange(ev.startIso, ev.endIso)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <p className="mt-12">
         <Link href="/" className="text-sm font-medium text-[var(--brand)] hover:underline">
           ← Back home
         </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,3 +19,12 @@ body {
   background: var(--background);
   color: var(--foreground);
 }
+
+/* Marketing hero mesh — premium-brand depth without stock photography budget */
+.marketing-hero-mesh {
+  background:
+    radial-gradient(ellipse 85% 65% at 15% 35%, rgba(245, 197, 66, 0.14), transparent 52%),
+    radial-gradient(ellipse 70% 55% at 85% 15%, rgba(99, 102, 241, 0.09), transparent 48%),
+    radial-gradient(ellipse 60% 40% at 50% 100%, rgba(245, 197, 66, 0.06), transparent 45%),
+    linear-gradient(180deg, #141820 0%, #0c0e12 55%);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { GlobalJsonLd } from "@/components/global-json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { getCanonicalSiteUrl } from "@/lib/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -15,6 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getCanonicalSiteUrl()),
   title: {
     default: "Pixel Vault Games",
     template: "%s · Pixel Vault Games",
@@ -39,6 +42,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col bg-[var(--background)] font-sans antialiased text-zinc-100`}
       >
+        <GlobalJsonLd />
         <SiteHeader />
         <main className="flex-1">{children}</main>
         <SiteFooter />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
+import {
+  formatEventRange,
+  getNextFeaturedEvent,
+} from "@/lib/events";
 import { site } from "@/lib/site";
 
 export default function HomePage() {
+  const nextSwap = getNextFeaturedEvent();
+
   return (
     <>
       <section className="relative overflow-hidden border-b border-white/10 bg-gradient-to-b from-[#151922] to-[var(--background)]">
@@ -38,6 +44,44 @@ export default function HomePage() {
               Console &amp; controller repair
             </Link>
           </div>
+
+          {nextSwap ? (
+            <div className="mt-10 max-w-xl rounded-xl border border-[var(--brand)]/35 bg-black/35 px-4 py-5 sm:px-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand)]">
+                Next swap
+              </p>
+              <p className="mt-2 text-lg font-semibold text-white">{nextSwap.title}</p>
+              <p className="mt-1 text-sm text-zinc-400">
+                {formatEventRange(nextSwap.startIso, nextSwap.endIso)}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-500">
+                {nextSwap.summary}
+              </p>
+              <Link
+                href={`/events/${nextSwap.slug}`}
+                className="mt-4 inline-flex text-sm font-semibold text-[var(--brand)] hover:underline"
+              >
+                Event details &amp; vendor notes →
+              </Link>
+            </div>
+          ) : (
+            <div className="mt-10 max-w-xl rounded-xl border border-white/10 bg-white/[0.03] px-4 py-5 sm:px-6">
+              <p className="text-sm font-medium text-zinc-300">Next swap date</p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-500">
+                Dates post here as soon as they&apos;re locked. Get announcements
+                first on{" "}
+                <a
+                  href={site.social.instagram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-[var(--brand)] hover:underline"
+                >
+                  Instagram
+                </a>
+                .
+              </p>
+            </div>
+          )}
         </div>
       </section>
 
@@ -47,8 +91,7 @@ export default function HomePage() {
             <h2 className="text-lg font-semibold text-white">Vendor swap meets</h2>
             <p className="mt-3 text-sm leading-relaxed text-zinc-400">
               Community tables alongside the shop — buyers, sellers, and regulars
-              in one room. Dates and vendor info will live here as we migrate
-              content.
+              in one room. Dates and vendor notes live on each event page.
             </p>
             <Link
               href="/events"

--- a/app/repair/page.tsx
+++ b/app/repair/page.tsx
@@ -1,29 +1,127 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { DropCta } from "@/components/marketing/drop-cta";
+import { GoogleReviewsStrip } from "@/components/marketing/google-quote-strip";
+import { IllustrationRepairBench } from "@/components/marketing/illustrations";
+import { PageHero } from "@/components/marketing/page-hero";
+import { PillRow } from "@/components/marketing/pill-row";
+import { site } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Repair",
-  description:
-    "Console and controller repair at Pixel Vault Games — Ontario, CA.",
+  description: `Console & controller repair at ${site.name} — honest diagnostics, saves-first mindset, Ontario CA.`,
 };
+
+const pills = [
+  "Diagnostics first",
+  "HDMI / power issues",
+  "Stick drift",
+  "Battery swaps",
+  "Disc trays",
+];
 
 export default function RepairPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
-      <h1 className="text-3xl font-semibold tracking-tight text-white">
-        Console &amp; controller repair
-      </h1>
-      <p className="mt-6 leading-relaxed text-zinc-400">
-        Dead console, stick drift, or a controller that gives up mid-run?
-        We&apos;ll expand this page with common services, turnaround expectations,
-        and photos from the bench — matching what regulars already expect in
-        store.
-      </p>
-      <p className="mt-10">
-        <Link href="/" className="text-sm font-medium text-[var(--brand)] hover:underline">
-          ← Back home
-        </Link>
-      </p>
-    </div>
+    <>
+      <PageHero
+        eyebrow="Bench — Ontario, CA"
+        title={
+          <>
+            Repair that respects{" "}
+            <span className="text-[var(--brand)]">your saves &amp; shells</span>
+          </>
+        }
+        subtitle="Dead HDMI on a Dreamcast? Wii drive buzz? Pro Controller drifting into lava pits? We troubleshoot like collectors — quote before work, explain risks before touching EEPROM."
+        illustration={
+          <div className="w-full max-w-[min(100%,320px)] drop-shadow-2xl drop-shadow-black/50">
+            <IllustrationRepairBench className="h-auto w-full" />
+            <p className="mt-3 text-center text-xs text-zinc-500">
+              Stylized illustration — drop bench photos into{" "}
+              <code className="rounded bg-white/5 px-1 text-[var(--brand)]">
+                /images/store/
+              </code>{" "}
+              when ready.
+            </p>
+          </div>
+        }
+      >
+        <PillRow items={pills} />
+      </PageHero>
+
+      <section className="border-t border-white/10 bg-black/25 py-16">
+        <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-3 lg:gap-10">
+          <article className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6 shadow-xl shadow-black/25">
+            <h2 className="text-lg font-semibold text-white">How it works</h2>
+            <ol className="mt-4 list-decimal space-y-3 pl-5 text-sm leading-relaxed text-zinc-400">
+              <li>Bring the console or controller — cables help if the fault is power/video.</li>
+              <li>We reproduce the issue on the bench and outline options + price bands.</li>
+              <li>You approve before we replace parts or reflow boards.</li>
+            </ol>
+          </article>
+          <article className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6 shadow-xl shadow-black/25">
+            <h2 className="text-lg font-semibold text-white">What we see often</h2>
+            <ul className="mt-4 space-y-2 text-sm text-zinc-400">
+              <li className="flex gap-2">
+                <span className="text-[var(--brand)]">→</span>
+                PS5 / Xbox Series stuck lasers &amp; HDMI pads
+              </li>
+              <li className="flex gap-2">
+                <span className="text-[var(--brand)]">→</span>
+                GameCube / Wii drive mechanics &amp; spindle wear
+              </li>
+              <li className="flex gap-2">
+                <span className="text-[var(--brand)]">→</span>
+                Handheld batteries &amp; hinge fatigue (DS / PSP family)
+              </li>
+            </ul>
+          </article>
+          <GoogleReviewsStrip />
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="grid gap-8 lg:grid-cols-2 lg:items-start">
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Data &amp; saves</h2>
+              <p className="mt-4 leading-relaxed text-zinc-400">
+                Whenever work risks storage — Wii NAND, handheld flash — we&apos;ll spell it out before
+                touching solder. If we can&apos;t guarantee a save, we&apos;ll say so upfront.
+              </p>
+              <p className="mt-4 leading-relaxed text-zinc-400">
+                Competitive scans showed collectors reward shops that speak plainly about risk.
+                No geek-shaming; just honest timelines.
+              </p>
+            </div>
+            <DropCta
+              title="Need a queue time?"
+              description="Busy Saturdays happen — call before you haul a CRT across county lines."
+              href="/contact"
+              label="Call or get directions"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 bg-gradient-to-b from-transparent to-black/30 py-14">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-6 px-4 sm:px-6">
+          <p className="text-sm text-zinc-500">
+            <Link href="/" className="text-[var(--brand)] hover:underline">
+              ← Home
+            </Link>
+            <span className="mx-2 text-zinc-700">·</span>
+            <Link href="/trade-in" className="hover:text-[var(--brand)]">
+              Trade-ins
+            </Link>
+          </p>
+          <Link
+            href="/events"
+            className="text-sm font-semibold text-[var(--brand)] hover:underline"
+          >
+            Swap meet weekends →
+          </Link>
+        </div>
+      </section>
+    </>
   );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { getCanonicalSiteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  const base = getCanonicalSiteUrl();
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${base}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+import { events } from "@/lib/events";
+import { getCanonicalSiteUrl } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = getCanonicalSiteUrl();
+  const paths = [
+    "",
+    "/events",
+    "/contact",
+    "/repair",
+    "/trade-in",
+    "/about",
+  ];
+
+  const items: MetadataRoute.Sitemap = paths.map((path) => ({
+    url: `${base}${path}`,
+    lastModified: new Date(),
+    changeFrequency: path === "" ? "weekly" : "monthly",
+    priority: path === "" ? 1 : 0.75,
+  }));
+
+  for (const e of events) {
+    items.push({
+      url: `${base}/events/${e.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.85,
+    });
+  }
+
+  return items;
+}

--- a/app/trade-in/page.tsx
+++ b/app/trade-in/page.tsx
@@ -1,28 +1,119 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { DropCta } from "@/components/marketing/drop-cta";
+import { GoogleReviewsStrip } from "@/components/marketing/google-quote-strip";
+import { IllustrationTradeBins } from "@/components/marketing/illustrations";
+import { PageHero } from "@/components/marketing/page-hero";
+import { PillRow } from "@/components/marketing/pill-row";
+import { site } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Trade-in",
-  description:
-    "Sell or trade games and hardware at Pixel Vault Games — Ontario, CA.",
+  description: `Sell or trade games and hardware at ${site.name} — fair quotes, clear expectations, Ontario CA.`,
 };
+
+const pills = ["Cash offers", "Store credit bump", "Testing on the spot", "Imports welcomed"];
 
 export default function TradeInPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
-      <h1 className="text-3xl font-semibold tracking-tight text-white">
-        Buy / sell / trade
-      </h1>
-      <p className="mt-6 leading-relaxed text-zinc-400">
-        We&apos;ll publish a transparent trade-in overview here — what we look for,
-        how quotes work, and what to bring — aligned with the roadmap for trust
-        and clarity.
-      </p>
-      <p className="mt-10">
-        <Link href="/" className="text-sm font-medium text-[var(--brand)] hover:underline">
-          ← Back home
-        </Link>
-      </p>
-    </div>
+    <>
+      <PageHero
+        eyebrow="Buy / sell / trade"
+        title={
+          <>
+            Trades that stay{" "}
+            <span className="text-[var(--brand)]">legible &amp; fair</span>
+          </>
+        }
+        subtitle="Bring bins or a single grail — we price against recent sold comps, condition in hand, and local demand. No algorithmic lowballs from behind a counter laptop."
+        illustration={
+          <div className="w-full max-w-[min(100%,320px)] drop-shadow-2xl drop-shadow-black/50">
+            <IllustrationTradeBins className="h-auto w-full" />
+            <p className="mt-3 text-center text-xs text-zinc-500">
+              Drop your real floor shots into{" "}
+              <code className="rounded bg-white/5 px-1 text-[var(--brand)]">
+                public/images/store/
+              </code>{" "}
+              when you have them.
+            </p>
+          </div>
+        }
+      >
+        <PillRow items={pills} />
+      </PageHero>
+
+      <section className="border-t border-white/10 bg-black/25 py-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="grid gap-10 lg:grid-cols-3">
+            <article className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+              <h2 className="text-lg font-semibold text-white">What moves fastest</h2>
+              <p className="mt-3 text-sm leading-relaxed text-zinc-400">
+                First-party Nintendo / Sony / Xbox, complete-in-box retro, handhelds with good
+                batteries, and weird import oddities with player demand.
+              </p>
+            </article>
+            <article className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+              <h2 className="text-lg font-semibold text-white">Condition honesty</h2>
+              <p className="mt-3 text-sm leading-relaxed text-zinc-400">
+                Label repro carts, swapped shells, or aftermarket batteries — we&apos;ll adjust
+                offers accordingly. Surprises after inspection don&apos;t help either side.
+              </p>
+            </article>
+            <GoogleReviewsStrip />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <h2 className="text-2xl font-semibold text-white">Quote transparency</h2>
+          <p className="mt-4 max-w-3xl leading-relaxed text-zinc-400">
+            Research for this site flagged published trade formulas as a trust accelerator — but
+            posting exact percentages is a business decision. Here&apos;s the promise instead:
+            we&apos;ll explain how we reached a number (comps, condition tier, local velocity) so you
+            can decide in the moment.
+          </p>
+          <div className="mt-10 grid gap-6 sm:grid-cols-2">
+            <div className="rounded-2xl border border-dashed border-[var(--brand)]/30 bg-[var(--brand)]/5 p-6">
+              <p className="text-sm font-semibold uppercase tracking-wider text-[var(--brand)]">
+                Credit bump
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                Store credit offers typically edge above cash — spend it on the floor the same day.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-[var(--surface)] p-6">
+              <p className="text-sm font-semibold text-white">Large lots</p>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                Buying collections? Call ahead if it&apos;s multiple bins — we&apos;ll carve out time so
+                nothing gets a rushed skim.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 bg-black/30 py-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <DropCta
+            title="Swing by with a tote"
+            description="Check posted retail hours — Tuesdays we&apos;re closed for restocking."
+            href="/contact"
+            label="Hours & directions"
+          />
+        </div>
+      </section>
+
+      <section className="py-12">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-6 px-4 sm:px-6">
+          <Link href="/" className="text-sm font-medium text-zinc-500 hover:text-[var(--brand)]">
+            ← Home
+          </Link>
+          <Link href="/repair" className="text-sm font-semibold text-[var(--brand)] hover:underline">
+            Repair services →
+          </Link>
+        </div>
+      </section>
+    </>
   );
 }

--- a/components/event-json-ld.tsx
+++ b/components/event-json-ld.tsx
@@ -1,0 +1,12 @@
+import type { ShopEvent } from "@/lib/events";
+import { buildEventJsonLd } from "@/lib/jsonld";
+
+export function EventJsonLd({ event }: { event: ShopEvent }) {
+  const data = buildEventJsonLd(event);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/global-json-ld.tsx
+++ b/components/global-json-ld.tsx
@@ -1,0 +1,12 @@
+import { buildGlobalJsonLd } from "@/lib/jsonld";
+
+/** Sitewide Store + WebSite JSON-LD — injected once from root layout */
+export function GlobalJsonLd() {
+  const data = buildGlobalJsonLd();
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/marketing/drop-cta.tsx
+++ b/components/marketing/drop-cta.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+/** Drop-shaped engagement: tie CTA to next visit / swap / bench queue — per competitor scan. */
+
+export function DropCta({
+  title,
+  description,
+  href,
+  label,
+}: {
+  title: string;
+  description: string;
+  href: string;
+  label: string;
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-[var(--brand)]/25 bg-gradient-to-br from-[var(--brand)]/15 via-transparent to-indigo-500/10 p-6 sm:p-8">
+      <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-[var(--brand)]/10 blur-3xl" />
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      <p className="mt-2 max-w-lg text-sm leading-relaxed text-zinc-400">{description}</p>
+      <Link
+        href={href}
+        className="mt-5 inline-flex items-center rounded-lg bg-[var(--brand)] px-4 py-2.5 text-sm font-semibold text-black shadow-lg shadow-amber-500/15 transition hover:bg-[var(--brand-dim)]"
+      >
+        {label}
+      </Link>
+    </div>
+  );
+}

--- a/components/marketing/google-quote-strip.tsx
+++ b/components/marketing/google-quote-strip.tsx
@@ -1,0 +1,19 @@
+/** Aggregate Google rating strip — press-quote wall pattern from competitor scan (earned social proof > anonymous testimonials). */
+
+export function GoogleReviewsStrip() {
+  return (
+    <aside className="rounded-2xl border border-[var(--brand)]/20 bg-gradient-to-br from-zinc-900/90 via-[var(--surface)] to-zinc-950 px-6 py-6 shadow-lg shadow-black/30">
+      <p className="text-lg font-semibold tracking-wide text-[var(--brand)]">
+        ★★★★★
+      </p>
+      <p className="mt-2 text-sm font-medium text-zinc-200">
+        Loved on Google Maps by locals &amp; collectors
+      </p>
+      <p className="mt-2 text-sm leading-relaxed text-zinc-500">
+        Pin your live star average here after you connect GBP widgets — until then,
+        we keep the focus on in-person trust: diagnose honestly, quote before work,
+        explain saves before wiping.
+      </p>
+    </aside>
+  );
+}

--- a/components/marketing/illustrations.tsx
+++ b/components/marketing/illustrations.tsx
@@ -1,0 +1,72 @@
+/** Decorative SVGs until legacy JPEGs land in /images/store/ — crisp at any size. */
+
+export function IllustrationRepairBench({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 320 240"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect width="320" height="240" rx="16" fill="#12161d" stroke="#2e3444" />
+      <path
+        d="M40 180h240v24H40v-24z"
+        fill="#1a2030"
+        stroke="#f5c542"
+        strokeOpacity="0.35"
+      />
+      <rect x="56" y="60" width="88" height="64" rx="6" fill="#2a3142" stroke="#f5c542" strokeOpacity="0.5" />
+      <path d="M72 92h56M72 108h40" stroke="#94a3b8" strokeWidth="3" strokeLinecap="round" />
+      <circle cx="200" cy="92" r="28" fill="#1e293b" stroke="#f5c542" strokeOpacity="0.45" />
+      <path d="M188 92h24M200 80v24" stroke="#f5c542" strokeOpacity="0.7" strokeWidth="4" strokeLinecap="round" />
+      <rect x="232" y="72" width="40" height="88" rx="4" fill="#262e3d" stroke="#64748b" />
+      <circle cx="252" cy="108" r="6" fill="#f5c542" fillOpacity="0.35" />
+    </svg>
+  );
+}
+
+export function IllustrationTradeBins({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 320 240"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect width="320" height="240" rx="16" fill="#12161d" stroke="#2e3444" />
+      <rect x="48" y="140" width="72" height="56" rx="8" fill="#1f2937" stroke="#f5c542" strokeOpacity="0.4" />
+      <rect x="124" y="128" width="72" height="68" rx="8" fill="#252f3f" stroke="#f5c542" strokeOpacity="0.55" />
+      <rect x="200" y="148" width="72" height="48" rx="8" fill="#1a2230" stroke="#64748b" />
+      <path d="M64 148h40M132 144h56M216 164h40" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" opacity="0.6" />
+      <circle cx="160" cy="48" r="4" fill="#f5c542" fillOpacity="0.9" />
+      <circle cx="172" cy="44" r="3" fill="#f5c542" fillOpacity="0.5" />
+    </svg>
+  );
+}
+
+export function IllustrationCommunity({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 320 240"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect width="320" height="240" rx="16" fill="#12161d" stroke="#2e3444" />
+      <circle cx="100" cy="100" r="36" fill="#1e293b" stroke="#f5c542" strokeOpacity="0.45" />
+      <circle cx="220" cy="88" r="32" fill="#252f3f" stroke="#f5c542" strokeOpacity="0.35" />
+      <circle cx="168" cy="152" r="40" fill="#1f2937" stroke="#94a3b8" strokeOpacity="0.5" />
+      <path
+        d="M120 100c24 8 48 8 72 0M152 152c20-12 40-12 60 0"
+        stroke="#f5c542"
+        strokeOpacity="0.25"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path d="M160 40v28" stroke="#f5c542" strokeOpacity="0.5" strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/components/marketing/page-hero.tsx
+++ b/components/marketing/page-hero.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+export function PageHero({
+  eyebrow,
+  title,
+  subtitle,
+  children,
+  illustration,
+}: {
+  eyebrow: string;
+  title: ReactNode;
+  subtitle: string;
+  children?: ReactNode;
+  illustration?: ReactNode;
+}) {
+  return (
+    <section className="relative overflow-hidden border-b border-white/10">
+      <div className="marketing-hero-mesh pointer-events-none absolute inset-0 opacity-90" />
+      <div className="relative mx-auto grid max-w-6xl gap-10 px-4 py-16 lg:grid-cols-[1.15fr_minmax(0,0.85fr)] lg:items-center lg:gap-14 lg:py-20">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[var(--brand)]">
+            {eyebrow}
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            {title}
+          </h1>
+          <p className="mt-6 max-w-xl text-lg leading-relaxed text-zinc-400">
+            {subtitle}
+          </p>
+          {children ? <div className="mt-8">{children}</div> : null}
+        </div>
+        {illustration ? (
+          <div className="flex justify-center lg:justify-end">{illustration}</div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/components/marketing/pill-row.tsx
+++ b/components/marketing/pill-row.tsx
@@ -1,0 +1,15 @@
+/** Status-style pills inspired by premium retro ecommerce cards — translates to service/inventory signals on a small-shop site. */
+
+export function PillRow({ items }: { items: string[] }) {
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {items.map((label) => (
+        <li key={label}>
+          <span className="inline-flex items-center rounded-full border border-[var(--brand)]/35 bg-[var(--brand)]/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--brand)]">
+            {label}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -69,8 +69,9 @@ export function SiteFooter() {
           </div>
         </div>
         <p className="mt-10 border-t border-white/5 pt-6 text-xs text-zinc-500">
-          © <span>{new Date().getFullYear()}</span> {site.name}. Family-owned
-          retro games and events in the Inland Empire.
+          ©{" "}
+          <span suppressHydrationWarning>{new Date().getFullYear()}</span>{" "}
+          {site.name}. Family-owned retro games and events in the Inland Empire.
         </p>
       </div>
     </footer>

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,119 @@
+/**
+ * Swap meets & store-hosted events. Edit this file to add dates — one slug per occurrence.
+ * Optional later: load from Markdown under /content/events with the same shape.
+ */
+
+export type ShopEvent = {
+  slug: string;
+  title: string;
+  /** Short line for cards / homepage */
+  summary: string;
+  /** Longer body for the detail page (plain text paragraphs, \\n\\n separated) */
+  description: string;
+  /** ISO 8601 with offset (America/Los_Angeles) */
+  startIso: string;
+  endIso: string;
+  /** Vendor-facing bullets shown on detail page */
+  vendorTips: string[];
+};
+
+export const events: ShopEvent[] = [
+  {
+    slug: "vault-swap-2026-05-17",
+    title: "Vault Swap — May",
+    summary: "Community tables, buyers, and sellers — one room, zero attitude.",
+    description:
+      "Our signature indoor swap meet: private sellers line the floor with bins and displays while the shop stays open for trades and impulse grabs. Bring cash, bring a wagon, and leave time to dig.\n\nFree to browse. Table rentals are first-come online announcement — watch Instagram for the signup drop.",
+    startIso: "2026-05-17T10:00:00-07:00",
+    endIso: "2026-05-17T16:00:00-07:00",
+    vendorTips: [
+      "Arrive up to 30 minutes early if you purchased a vendor slot — staff will direct load-in.",
+      "Power strips are limited; battery handhelds and complete-in-box welcome.",
+      "Children welcome with an adult; crowded aisles — wagons beat shoulder bags.",
+    ],
+  },
+  {
+    slug: "vault-swap-2026-06-14",
+    title: "Vault Swap — June",
+    summary: "Summer session — same energy, longer daylight.",
+    description:
+      "June swap: more daylight for late shoppers and a few extra tables when demand allows. Pixel Vault stays open for purchases, repair drop-off questions, and honest trade quotes.\n\nFollow @pixelvaultgames for vendor announcements and any schedule tweaks.",
+    startIso: "2026-06-14T10:00:00-07:00",
+    endIso: "2026-06-14T16:00:00-07:00",
+    vendorTips: [
+      "Hydrate — inland heat sneaks up even indoors.",
+      "Label imports or repro carts clearly; collectors appreciate transparency.",
+      "Need a repair quote? Bring the console to the counter during swap hours.",
+    ],
+  },
+  {
+    slug: "vault-swap-2026-04-26",
+    title: "Vault Swap — April (past)",
+    summary: "Archive reference — spring crowd, full floor.",
+    description:
+      "Archived listing from our April swap — kept so recurring visitors can see how we format schedules and vendor expectations.\n\nPhotos and reels usually hit Instagram first; the site mirrors confirmed dates.",
+    startIso: "2026-04-26T10:00:00-07:00",
+    endIso: "2026-04-26T16:00:00-07:00",
+    vendorTips: [
+      "Past event — details preserved for consistency.",
+    ],
+  },
+];
+
+function parseInstant(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+/** All events, soonest start first */
+export function getAllEventsSorted(): ShopEvent[] {
+  return [...events].sort(
+    (a, b) => parseInstant(a.startIso) - parseInstant(b.startIso),
+  );
+}
+
+export function getEventBySlug(slug: string): ShopEvent | undefined {
+  return events.find((e) => e.slug === slug);
+}
+
+/** Events whose end time is still in the future (relative to now). */
+export function getUpcomingEvents(now = new Date()): ShopEvent[] {
+  const t = now.getTime();
+  return getAllEventsSorted().filter((e) => parseInstant(e.endIso) >= t);
+}
+
+/** Events that already ended */
+export function getPastEvents(now = new Date()): ShopEvent[] {
+  const t = now.getTime();
+  return getAllEventsSorted()
+    .filter((e) => parseInstant(e.endIso) < t)
+    .reverse();
+}
+
+/** Next swap for homepage hero — undefined if none scheduled */
+export function getNextFeaturedEvent(now = new Date()): ShopEvent | undefined {
+  const upcoming = getUpcomingEvents(now);
+  return upcoming[0];
+}
+
+const TZ = "America/Los_Angeles";
+
+/** Human-readable range for cards and headings */
+export function formatEventRange(startIso: string, endIso: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const datePart = start.toLocaleDateString("en-US", {
+    timeZone: TZ,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timeFmt: Intl.DateTimeFormatOptions = {
+    timeZone: TZ,
+    hour: "numeric",
+    minute: "2-digit",
+  };
+  const startT = start.toLocaleTimeString("en-US", timeFmt);
+  const endT = end.toLocaleTimeString("en-US", timeFmt);
+  return `${datePart} · ${startT} – ${endT}`;
+}

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -1,0 +1,117 @@
+import type { ShopEvent } from "@/lib/events";
+import { formatStreetAddress, getCanonicalSiteUrl, site } from "@/lib/site";
+
+const SCHEMA = "https://schema.org";
+
+/** Full URLs for OpeningHoursSpecification dayOfWeek */
+const DAY = {
+  Monday: `${SCHEMA}/Monday`,
+  Tuesday: `${SCHEMA}/Tuesday`,
+  Wednesday: `${SCHEMA}/Wednesday`,
+  Thursday: `${SCHEMA}/Thursday`,
+  Friday: `${SCHEMA}/Friday`,
+  Saturday: `${SCHEMA}/Saturday`,
+  Sunday: `${SCHEMA}/Sunday`,
+} as const;
+
+export function buildGlobalJsonLd(): Record<string, unknown> {
+  const base = getCanonicalSiteUrl();
+  const storeId = `${base}/#store`;
+  const websiteId = `${base}/#website`;
+
+  return {
+    "@context": SCHEMA,
+    "@graph": [
+      {
+        "@type": ["Store", "LocalBusiness"],
+        "@id": storeId,
+        name: site.name,
+        description: site.tagline,
+        telephone: site.phoneTel,
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: site.address.street,
+          addressLocality: site.address.city,
+          addressRegion: site.address.region,
+          postalCode: site.address.postalCode,
+          addressCountry: site.address.country,
+        },
+        geo: {
+          "@type": "GeoCoordinates",
+          latitude: site.geo.latitude,
+          longitude: site.geo.longitude,
+        },
+        openingHoursSpecification: [
+          {
+            "@type": "OpeningHoursSpecification",
+            dayOfWeek: [
+              DAY.Monday,
+              DAY.Wednesday,
+              DAY.Thursday,
+              DAY.Friday,
+              DAY.Saturday,
+            ],
+            opens: "12:00",
+            closes: "18:00",
+          },
+          {
+            "@type": "OpeningHoursSpecification",
+            dayOfWeek: DAY.Sunday,
+            opens: "12:00",
+            closes: "16:00",
+          },
+        ],
+        sameAs: [
+          site.social.instagram,
+          site.social.facebook,
+          site.social.youtube,
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        url: base,
+        name: site.name,
+        publisher: { "@id": storeId },
+      },
+    ],
+  };
+}
+
+export function buildEventJsonLd(ev: ShopEvent): Record<string, unknown> {
+  const base = getCanonicalSiteUrl();
+  const storeId = `${base}/#store`;
+  const pageUrl = `${base}/events/${ev.slug}`;
+
+  return {
+    "@context": SCHEMA,
+    "@type": "Event",
+    "@id": `${pageUrl}#event`,
+    name: ev.title,
+    description: ev.summary,
+    url: pageUrl,
+    startDate: ev.startIso,
+    endDate: ev.endIso,
+    eventStatus: `${SCHEMA}/EventScheduled`,
+    eventAttendanceMode: `${SCHEMA}/OfflineEventAttendanceMode`,
+    location: {
+      "@type": "Place",
+      name: site.name,
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: site.address.street,
+        addressLocality: site.address.city,
+        addressRegion: site.address.region,
+        postalCode: site.address.postalCode,
+        addressCountry: site.address.country,
+      },
+      geo: {
+        "@type": "GeoCoordinates",
+        latitude: site.geo.latitude,
+        longitude: site.geo.longitude,
+      },
+      hasMap: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(formatStreetAddress())}`,
+    },
+    organizer: { "@id": storeId },
+  };
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,4 +1,12 @@
-/** Single source for NAP + nav — update here when canonical hours/phone are finalized. */
+/** Single source for NAP + nav — confirm hours vs Google Business Profile before launch. */
+
+export function getCanonicalSiteUrl(): string {
+  const u = process.env.NEXT_PUBLIC_SITE_URL;
+  if (typeof u === "string" && u.trim().length > 0) {
+    return u.replace(/\/$/, "");
+  }
+  return "http://localhost:3000";
+}
 
 export const site = {
   name: "Pixel Vault Games",
@@ -14,15 +22,36 @@ export const site = {
     postalCode: "91762",
     country: "US",
   },
+  /** Approximate coordinates for JSON-LD — tune from GBP / Maps pin if needed */
+  geo: {
+    latitude: 34.0639,
+    longitude: -117.6512,
+  },
   /** Confirm against Google Business Profile — BusinessYab listed a variant digit historically */
   phoneDisplay: "(909) 664-7634",
   phoneTel: "+19096647634",
+  /** Used in JSON-LD @id — must match public site URL in production */
   social: {
     instagram: "https://www.instagram.com/pixelvaultgames",
     facebook: "https://www.facebook.com/PixelVaultGames",
     youtube:
       "https://www.youtube.com/channel/UCKONxFboO1zJNbvhPsbp5mQ",
   },
+  /**
+   * Canonical retail hours. Tuesday is closed — resolves the legacy Contact page
+   * contradiction (“closed Tuesdays” vs “Tue–Sat open”).
+   */
+  hours: {
+    timeZone: "America/Los_Angeles",
+    lines: [
+      "Monday 12:00 PM – 6:00 PM",
+      "Tuesday — Closed",
+      "Wednesday–Saturday 12:00 PM – 6:00 PM",
+      "Sunday 12:00 PM – 4:00 PM",
+    ],
+  },
+  parkingNote:
+    "Parking is available in the lot; Holt Blvd also has street parking. Swap days get busy — arrive early if you’re hauling bins.",
 } as const;
 
 export type NavItem = { href: string; label: string };
@@ -35,3 +64,8 @@ export const mainNav: NavItem[] = [
   { href: "/about", label: "About" },
   { href: "/contact", label: "Visit" },
 ];
+
+export function formatStreetAddress(): string {
+  const { street, city, region, postalCode } = site.address;
+  return `${street}, ${city}, ${region} ${postalCode}`;
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,9 +1,16 @@
 /** Single source for NAP + nav — confirm hours vs Google Business Profile before launch. */
 
+/** Public production origin — JSON-LD, sitemap, metadataBase. Apex domain (no www). */
+export const productionSiteOrigin = "https://pixelvaultontario.com";
+
 export function getCanonicalSiteUrl(): string {
   const u = process.env.NEXT_PUBLIC_SITE_URL;
   if (typeof u === "string" && u.trim().length > 0) {
     return u.replace(/\/$/, "");
+  }
+  /* Vercel sets VERCEL=1 — safe default so OG/sitemap URLs match the live domain if env is missing */
+  if (process.env.VERCEL === "1") {
+    return productionSiteOrigin;
   }
   return "http://localhost:3000";
 }

--- a/public/images/store/README.md
+++ b/public/images/store/README.md
@@ -1,0 +1,11 @@
+# Store photography (from legacy site)
+
+Copy JPEGs from your **legacy deploy** or backups into this folder using these filenames so `next/image` can pick them up:
+
+| File | Legacy reference (`legacy/webpack-site/client/src/Home.jsx`) |
+|------|----------------------------------------------------------------|
+| `games-in-case.jpg` | `../assets/gamesInCase.jpeg` — NES display case |
+| `consoles-controllers.jpg` | `../assets/consolesAndControllers.jpeg` — boxed consoles & controllers |
+| `store-display.jpg` | `../assets/storeDisplay2.jpeg` — character / in-store display |
+
+After adding files, update pages to use `<Image src="/images/store/..." />` instead of illustrations where desired.


### PR DESCRIPTION
## Includes

This branch stacks on **`feat/marketing-p0`** (canonical domain, events slugs, Visit page, JSON-LD, sitemap). If **[PR #8](https://github.com/Chris-McVey/pixelVault/pull/8)** is still open, you can **close it** and merge this PR only, or merge #8 first — avoid merging both into `main` without reconciling.

## P1 — Stub pages fleshed out

- **`/repair`** — bench narrative, diagnostics flow, saves/NAND honesty, service pills, Google quote strip, drop CTA → Visit.
- **`/trade-in`** — transparency framing (formula is business-owned), cash vs credit bump, condition honesty, competitor-scan voice.
- **`/about`** — family-owned / swap-forward story, milestone rail, drop CTA → Events.

## Design language (competitor analysis)

- **Status pills** (`PillRow`) — premium-card pattern adapted for services/offers.
- **Quote strip** (`GoogleReviewsStrip`) — aggregate social proof > anonymous testimonials.
- **Drop CTAs** (`DropCta`) — event / bench urgency without fake countdowns.
- **Hero mesh** — `.marketing-hero-mesh` gradients for depth without stock-photo budget.

## Legacy imagery

JPEGs are **not** in git (same as legacy audit). **`public/images/store/README.md`** maps legacy `Home.jsx` asset names → drop-in filenames for `next/image` later.

## Follow-up

Add real photos to `public/images/store/` and swap illustrations for `<Image />` where desired.